### PR TITLE
keycloak jwt token decoding fix

### DIFF
--- a/app/models/oic_session.rb
+++ b/app/models/oic_session.rb
@@ -86,7 +86,7 @@ class OicSession < ActiveRecord::Base
 
   def self.parse_token(token)
     jwt = token.split('.')
-    return JSON::parse(Base64::decode64(jwt[1]))
+    return JSON::parse(Base64::urlsafe_decode64(jwt[1]))
   end
 
   def claims
@@ -143,7 +143,7 @@ class OicSession < ActiveRecord::Base
 
   def user
     if @user.blank? || id_token_changed?
-      @user = JSON::parse(Base64::decode64(id_token.split('.')[1]))
+      @user = JSON::parse(Base64::urlsafe_decode64(id_token.split('.')[1]))
     end
     return @user
   end


### PR DESCRIPTION
use urlsafe_decode64 for jwt token